### PR TITLE
Modernize project to 2026 standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - run: go build ./...
+      - run: go test -race -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: go

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![GoDoc](https://godoc.org/github.com/mxschmitt/golang-safe-in-cloud?status.svg)](http://godoc.org/github.com/mxschmitt/golang-safe-in-cloud)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 [![Go Report](https://img.shields.io/badge/Go_report-A+-brightgreen.svg)](http://goreportcard.com/report/mxschmitt/golang-safe-in-cloud)
-[![Build Status](https://travis-ci.org/mxschmitt/golang-safe-in-cloud.svg?branch=master)](https://travis-ci.org/mxschmitt/golang-safe-in-cloud)
+[![CI](https://github.com/mxschmitt/golang-safe-in-cloud/actions/workflows/ci.yml/badge.svg)](https://github.com/mxschmitt/golang-safe-in-cloud/actions/workflows/ci.yml)
 
 # SafeInCloud Golang Decryption
 

--- a/decrypt.go
+++ b/decrypt.go
@@ -8,15 +8,15 @@ import (
 	"crypto/cipher"
 	"crypto/sha1"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
-	"io/ioutil"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/pbkdf2"
 )
 
 // ErrIncorrectPassword means that the credentials are incorrect
-var ErrIncorrectPassword = errors.New("Incorrect credentials")
+var ErrIncorrectPassword = errors.New("incorrect credentials")
 
 // Decrypt decrypts a SafeInCloud database by a given file (e.g. os.Open)
 // and a password
@@ -25,41 +25,41 @@ func Decrypt(file io.Reader, password string) ([]byte, error) {
 	var magic uint16
 	// Decrypt the FD
 	if err := binary.Read(data, binary.LittleEndian, &magic); err != nil {
-		return nil, errors.Wrap(err, "could not read magic")
+		return nil, fmt.Errorf("could not read magic: %w", err)
 	}
 	if _, err := data.ReadByte(); err != nil {
-		return nil, errors.Wrap(err, "could not read sver")
+		return nil, fmt.Errorf("could not read sver: %w", err)
 	}
 	salt, err := readByteArray(data)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read salt")
+		return nil, fmt.Errorf("could not read salt: %w", err)
 	}
 	nonce, err := readByteArray(data)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read nonce")
+		return nil, fmt.Errorf("could not read nonce: %w", err)
 	}
 	pwd := pbkdf2.Key([]byte(password), salt, 10000, 32, sha1.New)
 	_, err = readByteArray(data) // Idk what this is; salt but not necessary?!
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read salt")
+		return nil, fmt.Errorf("could not read salt: %w", err)
 	}
 	block, err := readByteArray(data)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read subfd")
+		return nil, fmt.Errorf("could not read subfd: %w", err)
 	}
 	if err := decryptAES(pwd, nonce, &block); err != nil {
-		return nil, errors.Wrap(err, "could not decrypt aes")
+		return nil, fmt.Errorf("could not decrypt aes: %w", err)
 	}
 	fd := bufio.NewReader(bytes.NewBuffer(block))
-	encFile, err := ioutil.ReadAll(data)
+	encFile, err := io.ReadAll(data)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read remaining encrypted content")
+		return nil, fmt.Errorf("could not read remaining encrypted content: %w", err)
 	}
 	nonce, err = readByteArray(fd)
 	if err == io.ErrUnexpectedEOF {
 		return nil, ErrIncorrectPassword
 	} else if err != nil {
-		return nil, errors.Wrap(err, "could not read nonce")
+		return nil, fmt.Errorf("could not read nonce: %w", err)
 	}
 	pwd, err = readByteArray(fd)
 	if err != nil {
@@ -69,20 +69,20 @@ func Decrypt(file io.Reader, password string) ([]byte, error) {
 		return nil, err
 	}
 	if err := decryptAES(pwd, nonce, &encFile); err != nil {
-		return nil, errors.Wrap(err, "could not decrypt aes")
+		return nil, fmt.Errorf("could not decrypt aes: %w", err)
 	}
 	zReader, err := zlib.NewReader(bytes.NewReader(encFile))
 	if err != nil {
 		return nil, err
 	}
 	defer zReader.Close()
-	return ioutil.ReadAll(zReader)
+	return io.ReadAll(zReader)
 }
 
 func decryptAES(pwd, nonce []byte, content *[]byte) error {
 	block, err := aes.NewCipher(pwd)
 	if err != nil {
-		return errors.Wrap(err, "could not create cipher")
+		return fmt.Errorf("could not create cipher: %w", err)
 	}
 	cipher.NewCBCDecrypter(block, nonce).CryptBlocks(*content, *content)
 	return nil

--- a/decrypt_test.go
+++ b/decrypt_test.go
@@ -17,7 +17,7 @@ func TestDecrytionSuccess(t *testing.T) {
 	}
 	db, err := Unmarshal(raw)
 	if err != nil {
-		t.Errorf("could not unmarshal xml", err)
+		t.Errorf("could not unmarshal xml: %v", err)
 	}
 	tt := []struct {
 		expected string

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/mxschmitt/golang-safe-in-cloud
+
+go 1.23
+
+require golang.org/x/crypto v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -2,8 +2,7 @@ package sic
 
 import (
 	"encoding/xml"
-
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 type Database struct {
@@ -58,5 +57,8 @@ type File struct {
 // Unmarshal converts the xml in []byte into a Go struct
 func Unmarshal(raw []byte) (*Database, error) {
 	var db *Database
-	return db, errors.Wrap(xml.Unmarshal(raw, &db), "could not Unmarshal xml")
+	if err := xml.Unmarshal(raw, &db); err != nil {
+		return nil, fmt.Errorf("could not Unmarshal xml: %w", err)
+	}
+	return db, nil
 }


### PR DESCRIPTION
## Summary
- Add `go.mod`/`go.sum` (Go 1.23) — replaces the GOPATH-era layout
- Drop `io/ioutil` (deprecated since Go 1.16) and `github.com/pkg/errors` (unmaintained); use stdlib `io` and `fmt.Errorf` with `%w`
- Replace Travis CI with GitHub Actions (`.github/workflows/ci.yml`); update README badge
- Fix `t.Errorf` in `decrypt_test.go` that passed `err` to a format string with no verb

This brings the repo onto current Go tooling so #1 (encryption feature) can be built on a modern baseline.

## Test plan
- [x] `go test -race -v ./...` passes locally (both existing tests green)
- [ ] CI workflow runs on push and goes green