### PR TITLE
Add Encrypt, Marshal, and GenerateTestDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,27 @@
-debug*
+# Created by https://www.toptal.com/developers/gitignore/api/go
+# Edit at https://www.toptal.com/developers/gitignore?templates=go
+
+### Go ###
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# End of https://www.toptal.com/developers/gitignore/api/go

--- a/encrypt.go
+++ b/encrypt.go
@@ -1,0 +1,129 @@
+package sic
+
+import (
+	"bytes"
+	"compress/zlib"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// Encrypt encrypts decrypted SafeInCloud database XML using the given
+// password, producing a payload that round-trips through Decrypt.
+func Encrypt(raw []byte, password string) ([]byte, error) {
+	out := &bytes.Buffer{}
+	if err := binary.Write(out, binary.LittleEndian, uint16(0x0505)); err != nil {
+		return nil, fmt.Errorf("could not write magic: %w", err)
+	}
+	if err := out.WriteByte(0x01); err != nil {
+		return nil, fmt.Errorf("could not write sver: %w", err)
+	}
+	salt, err := randomBytes(16)
+	if err != nil {
+		return nil, fmt.Errorf("could not generate salt: %w", err)
+	}
+	if err := writeByteArray(out, salt); err != nil {
+		return nil, fmt.Errorf("could not write salt: %w", err)
+	}
+	outerNonce, err := randomBytes(16)
+	if err != nil {
+		return nil, fmt.Errorf("could not generate nonce: %w", err)
+	}
+	if err := writeByteArray(out, outerNonce); err != nil {
+		return nil, fmt.Errorf("could not write nonce: %w", err)
+	}
+	outerKey := pbkdf2.Key([]byte(password), salt, 10000, 32, sha1.New)
+	if err := writeByteArray(out, nil); err != nil {
+		return nil, fmt.Errorf("could not write mystery salt: %w", err)
+	}
+
+	innerNonce, err := randomBytes(16)
+	if err != nil {
+		return nil, fmt.Errorf("could not generate inner nonce: %w", err)
+	}
+	innerKey, err := randomBytes(32)
+	if err != nil {
+		return nil, fmt.Errorf("could not generate inner key: %w", err)
+	}
+	fd := &bytes.Buffer{}
+	if err := writeByteArray(fd, innerNonce); err != nil {
+		return nil, fmt.Errorf("could not write inner nonce: %w", err)
+	}
+	if err := writeByteArray(fd, innerKey); err != nil {
+		return nil, fmt.Errorf("could not write inner key: %w", err)
+	}
+	if err := writeByteArray(fd, nil); err != nil {
+		return nil, fmt.Errorf("could not write inner trailer: %w", err)
+	}
+	fdCipher := pkcs7Pad(fd.Bytes(), aes.BlockSize)
+	if err := encryptAES(outerKey, outerNonce, &fdCipher); err != nil {
+		return nil, fmt.Errorf("could not encrypt fd: %w", err)
+	}
+	if err := writeByteArray(out, fdCipher); err != nil {
+		return nil, fmt.Errorf("could not write fd: %w", err)
+	}
+
+	zBuf := &bytes.Buffer{}
+	zWriter := zlib.NewWriter(zBuf)
+	if _, err := zWriter.Write(raw); err != nil {
+		return nil, fmt.Errorf("could not zlib-compress: %w", err)
+	}
+	if err := zWriter.Close(); err != nil {
+		return nil, fmt.Errorf("could not close zlib writer: %w", err)
+	}
+	body := pkcs7Pad(zBuf.Bytes(), aes.BlockSize)
+	if err := encryptAES(innerKey, innerNonce, &body); err != nil {
+		return nil, fmt.Errorf("could not encrypt body: %w", err)
+	}
+	if _, err := out.Write(body); err != nil {
+		return nil, fmt.Errorf("could not write body: %w", err)
+	}
+	return out.Bytes(), nil
+}
+
+func encryptAES(key, nonce []byte, content *[]byte) error {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return fmt.Errorf("could not create cipher: %w", err)
+	}
+	cipher.NewCBCEncrypter(block, nonce).CryptBlocks(*content, *content)
+	return nil
+}
+
+func writeByteArray(w io.Writer, b []byte) error {
+	if len(b) > 255 {
+		return fmt.Errorf("byte array exceeds 255 bytes: %d", len(b))
+	}
+	if _, err := w.Write([]byte{byte(len(b))}); err != nil {
+		return err
+	}
+	if len(b) == 0 {
+		return nil
+	}
+	_, err := w.Write(b)
+	return err
+}
+
+func pkcs7Pad(b []byte, blockSize int) []byte {
+	pad := blockSize - len(b)%blockSize
+	out := make([]byte, len(b)+pad)
+	copy(out, b)
+	for i := len(b); i < len(out); i++ {
+		out[i] = byte(pad)
+	}
+	return out
+}
+
+func randomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -1,0 +1,59 @@
+package sic
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	xml, err := os.ReadFile("decrypt_test.xml")
+	if err != nil {
+		t.Fatalf("could not read xml: %v", err)
+	}
+	enc, err := Encrypt(xml, "foobar")
+	if err != nil {
+		t.Fatalf("could not encrypt: %v", err)
+	}
+	dec, err := Decrypt(bytes.NewReader(enc), "foobar")
+	if err != nil {
+		t.Fatalf("could not decrypt: %v", err)
+	}
+	if !bytes.Equal(xml, dec) {
+		t.Errorf("round-trip mismatch: %d in, %d out", len(xml), len(dec))
+	}
+}
+
+func TestEncryptWrongPassword(t *testing.T) {
+	enc, err := Encrypt([]byte("<database/>"), "right")
+	if err != nil {
+		t.Fatalf("could not encrypt: %v", err)
+	}
+	if _, err := Decrypt(bytes.NewReader(enc), "wrong"); err == nil {
+		t.Errorf("expected decryption to fail with wrong password")
+	}
+}
+
+func TestGenerateTestDB(t *testing.T) {
+	enc, err := GenerateTestDB("foobar")
+	if err != nil {
+		t.Fatalf("could not generate: %v", err)
+	}
+	raw, err := Decrypt(bytes.NewReader(enc), "foobar")
+	if err != nil {
+		t.Fatalf("could not decrypt: %v", err)
+	}
+	db, err := Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("could not unmarshal: %v", err)
+	}
+	if len(db.Card) != 1 || db.Card[0].ID != "100" || db.Card[0].Title != "Sample" {
+		t.Errorf("unexpected card: %+v", db.Card)
+	}
+	if len(db.Card[0].Field) != 2 || db.Card[0].Field[0].Text != "user@example.com" {
+		t.Errorf("unexpected field: %+v", db.Card[0].Field)
+	}
+	if len(db.Label) != 1 || db.Label[0].Name != "Test" {
+		t.Errorf("unexpected label: %+v", db.Label)
+	}
+}

--- a/fixture.go
+++ b/fixture.go
@@ -1,0 +1,29 @@
+package sic
+
+import "fmt"
+
+// GenerateTestDB builds a small SafeInCloud database with sample data and
+// returns it encrypted under the given password. Useful for tests that need
+// a realistic .db payload without depending on a checked-in fixture.
+func GenerateTestDB(password string) ([]byte, error) {
+	db := &Database{
+		Label: []Label{
+			{ID: "1", Name: "Test"},
+		},
+		Card: []Card{
+			{
+				ID:    "100",
+				Title: "Sample",
+				Field: []Field{
+					{Name: "Login", Type: "login", Text: "user@example.com"},
+					{Name: "Password", Type: "password", Text: "hunter2"},
+				},
+			},
+		},
+	}
+	raw, err := Marshal(db)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal sample db: %w", err)
+	}
+	return Encrypt(raw, password)
+}

--- a/marshal.go
+++ b/marshal.go
@@ -1,0 +1,18 @@
+package sic
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// Marshal converts a Database into the XML representation expected by Encrypt.
+func Marshal(db *Database) ([]byte, error) {
+	body, err := xml.MarshalIndent(db, "", "\t")
+	if err != nil {
+		return nil, fmt.Errorf("could not Marshal xml: %w", err)
+	}
+	out := make([]byte, 0, len(xml.Header)+len(body))
+	out = append(out, []byte(xml.Header)...)
+	out = append(out, body...)
+	return out, nil
+}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Database struct {
+	XMLName xml.Name `xml:"database"`
 	Notes   []string `xml:"notes"`
 	LabelID []string `xml:"label_id"`
 	File    [][]File `xml:"file"`


### PR DESCRIPTION
Closes #1.

## Summary
- `Encrypt(xml, password) ([]byte, error)` — full inverse of `Decrypt`: PBKDF2-SHA1 key derivation, AES-256-CBC outer FD block, AES-256-CBC body of zlib-compressed XML, with PKCS#7 padding. Magic/sver match the existing `decrypt_test.db` fixture (`0x0505` / `0x01`).
- `Marshal(*Database) ([]byte, error)` — produces XML with the lowercase `<database>` root the format uses.
- `GenerateTestDB(password)` — builds a sample DB (one label, one card with login/password fields) and returns it encrypted. Lets downstream tests generate fixtures without depending on the macOS `Safe.app` client (which has no AppleScript/CLI surface).

## Test plan
- [x] `go test -race -v ./...` — all 5 tests pass (2 existing + 3 new)
- [x] `go test -count=100 -run TestEncryptWrongPassword` — wrong-password rejection is robust across many random keys
- [x] `go vet ./...`, `go build ./...`
- [ ] CI green