### PR TITLE
Quality pass: stdlib pbkdf2, schema completeness, CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,23 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.24', 'stable']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: ${{ matrix.go }}
       - run: go build ./...
+      - run: go vet ./...
       - run: go test -race -v ./...
+      - name: Verify go.mod is tidy
+        run: go mod tidy && git diff --exit-code go.mod

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/mxschmitt/golang-safe-in-cloud/issues)
-[![GoDoc](https://godoc.org/github.com/mxschmitt/golang-safe-in-cloud?status.svg)](http://godoc.org/github.com/mxschmitt/golang-safe-in-cloud)
+[![Go Reference](https://pkg.go.dev/badge/github.com/mxschmitt/golang-safe-in-cloud.svg)](https://pkg.go.dev/github.com/mxschmitt/golang-safe-in-cloud)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 [![Go Report](https://img.shields.io/badge/Go_report-A+-brightgreen.svg)](http://goreportcard.com/report/mxschmitt/golang-safe-in-cloud)
 [![CI](https://github.com/mxschmitt/golang-safe-in-cloud/actions/workflows/ci.yml/badge.svg)](https://github.com/mxschmitt/golang-safe-in-cloud/actions/workflows/ci.yml)
 
-# SafeInCloud Golang Decryption
+# SafeInCloud Golang
 
-Provides decryption of a SafeInCloud database in Golang.
+Encrypt and decrypt [SafeInCloud](https://www.safe-in-cloud.com) database files in pure Go. Zero external dependencies; Go 1.24+.
 
-# Example
+## Decrypt
 
-```golang
+```go
 package main
 
 import (
@@ -18,7 +18,7 @@ import (
     "log"
     "os"
 
-    "github.com/mxschmitt/golang-safe-in-cloud"
+    sic "github.com/mxschmitt/golang-safe-in-cloud"
 )
 
 func main() {
@@ -31,10 +31,39 @@ func main() {
         log.Fatalf("could not decrypt: %v", err)
     }
     fmt.Println(string(raw))
-    x, err := sic.Unmarshal(raw)
+    db, err := sic.Unmarshal(raw)
     if err != nil {
         log.Fatalf("could not unmarshal: %v", err)
     }
-    fmt.Printf("data: %+v\n", x)
+    fmt.Printf("data: %+v\n", db)
 }
 ```
+
+## Encrypt
+
+```go
+db := &sic.Database{
+    Card: []sic.Card{{
+        ID:    "1",
+        Title: "Example",
+        Field: []sic.Field{{Name: "Login", Type: "login", Text: "user@example.com"}},
+    }},
+}
+raw, err := sic.Marshal(db)
+if err != nil {
+    log.Fatal(err)
+}
+enc, err := sic.Encrypt(raw, "foobar")
+if err != nil {
+    log.Fatal(err)
+}
+if err := os.WriteFile("SafeInCloud.db", enc, 0o600); err != nil {
+    log.Fatal(err)
+}
+```
+
+For tests, `sic.GenerateTestDB(password)` returns an encrypted database with sample data.
+
+## Note
+
+The on-disk format uses PBKDF2-SHA1 (10,000 iterations) and AES-CBC as required by SafeInCloud's file format; this is dictated by interoperability with the official client, not by current cryptographic best practice.

--- a/decrypt.go
+++ b/decrypt.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package sic
 
 import (
@@ -6,13 +8,12 @@ import (
 	"compress/zlib"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/pbkdf2"
 	"crypto/sha1"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
 // ErrIncorrectPassword means that the credentials are incorrect
@@ -38,7 +39,10 @@ func Decrypt(file io.Reader, password string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read nonce: %w", err)
 	}
-	pwd := pbkdf2.Key([]byte(password), salt, 10000, 32, sha1.New)
+	pwd, err := pbkdf2.Key(sha1.New, password, salt, 10000, 32)
+	if err != nil {
+		return nil, fmt.Errorf("could not derive key: %w", err)
+	}
 	_, err = readByteArray(data) // Idk what this is; salt but not necessary?!
 	if err != nil {
 		return nil, fmt.Errorf("could not read salt: %w", err)
@@ -55,20 +59,20 @@ func Decrypt(file io.Reader, password string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read remaining encrypted content: %w", err)
 	}
-	nonce, err = readByteArray(fd)
-	if err == io.ErrUnexpectedEOF {
+	innerNonce, err := readByteArray(fd)
+	if errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, ErrIncorrectPassword
 	} else if err != nil {
 		return nil, fmt.Errorf("could not read nonce: %w", err)
 	}
-	pwd, err = readByteArray(fd)
+	innerKey, err := readByteArray(fd)
 	if err != nil {
 		return nil, ErrIncorrectPassword
 	}
 	if _, err = readByteArray(fd); err != nil {
 		return nil, err
 	}
-	if err := decryptAES(pwd, nonce, &encFile); err != nil {
+	if err := decryptAES(innerKey, innerNonce, &encFile); err != nil {
 		return nil, fmt.Errorf("could not decrypt aes: %w", err)
 	}
 	zReader, err := zlib.NewReader(bytes.NewReader(encFile))

--- a/decrypt.go
+++ b/decrypt.go
@@ -79,7 +79,7 @@ func Decrypt(file io.Reader, password string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer zReader.Close()
+	defer func() { _ = zReader.Close() }()
 	return io.ReadAll(zReader)
 }
 

--- a/decrypt_test.go
+++ b/decrypt_test.go
@@ -1,12 +1,15 @@
+// SPDX-License-Identifier: MIT
+
 package sic
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
 )
 
-func TestDecrytionSuccess(t *testing.T) {
+func TestDecryptionSuccess(t *testing.T) {
 	file, err := os.Open("decrypt_test.db")
 	if err != nil {
 		t.Errorf("could not read file: %v", err)
@@ -57,7 +60,7 @@ func TestDecryptionInvalidPassword(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not read file: %v", err)
 	}
-	if _, err = Decrypt(file, "definitely not correct"); err != ErrIncorrectPassword {
-		t.Errorf("could not decrypt: %v", err)
+	if _, err = Decrypt(file, "definitely not correct"); !errors.Is(err, ErrIncorrectPassword) {
+		t.Errorf("expected ErrIncorrectPassword, got: %v", err)
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+
+// Package sic provides encryption and decryption of SafeInCloud database files.
+//
+// See https://www.safe-in-cloud.com for the underlying password manager.
+package sic

--- a/encrypt.go
+++ b/encrypt.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package sic
 
 import (
@@ -5,13 +7,12 @@ import (
 	"compress/zlib"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha1"
 	"encoding/binary"
 	"fmt"
 	"io"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
 // Encrypt encrypts decrypted SafeInCloud database XML using the given
@@ -38,7 +39,10 @@ func Encrypt(raw []byte, password string) ([]byte, error) {
 	if err := writeByteArray(out, outerNonce); err != nil {
 		return nil, fmt.Errorf("could not write nonce: %w", err)
 	}
-	outerKey := pbkdf2.Key([]byte(password), salt, 10000, 32, sha1.New)
+	outerKey, err := pbkdf2.Key(sha1.New, password, salt, 10000, 32)
+	if err != nil {
+		return nil, fmt.Errorf("could not derive key: %w", err)
+	}
 	if err := writeByteArray(out, nil); err != nil {
 		return nil, fmt.Errorf("could not write mystery salt: %w", err)
 	}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -1,7 +1,11 @@
+// SPDX-License-Identifier: MIT
+
 package sic
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"os"
 	"testing"
 )
@@ -31,6 +35,66 @@ func TestEncryptWrongPassword(t *testing.T) {
 	}
 	if _, err := Decrypt(bytes.NewReader(enc), "wrong"); err == nil {
 		t.Errorf("expected decryption to fail with wrong password")
+	}
+}
+
+func TestWriteByteArrayTooLarge(t *testing.T) {
+	if err := writeByteArray(io.Discard, make([]byte, 256)); err == nil {
+		t.Error("expected error for >255 bytes, got nil")
+	}
+}
+
+func TestDecryptCorruptedZlib(t *testing.T) {
+	enc, err := Encrypt([]byte("<database/>"), "foobar")
+	if err != nil {
+		t.Fatalf("could not encrypt: %v", err)
+	}
+	enc[len(enc)-1] ^= 0xFF
+	_, err = Decrypt(bytes.NewReader(enc), "foobar")
+	if err == nil {
+		t.Fatal("expected error from corrupted body")
+	}
+	if errors.Is(err, ErrIncorrectPassword) {
+		t.Errorf("corrupted body should not surface as ErrIncorrectPassword: %v", err)
+	}
+}
+
+func TestMarshalRoundTripWithNewAttributes(t *testing.T) {
+	in := &Database{
+		Card: []Card{{
+			ID:         "1",
+			Title:      "T",
+			Autofill:   "on",
+			FirstStamp: "12345",
+			Field: []Field{{
+				Name:     "Login",
+				Type:     "login",
+				Text:     "u",
+				Autofill: "username",
+			}},
+		}},
+	}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out, err := Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Card[0].Autofill != "on" || out.Card[0].FirstStamp != "12345" {
+		t.Errorf("card attrs lost: %+v", out.Card[0])
+	}
+	if out.Card[0].Field[0].Autofill != "username" {
+		t.Errorf("field autofill lost: %+v", out.Card[0].Field[0])
+	}
+
+	bare, err := Marshal(&Database{Card: []Card{{ID: "1"}}})
+	if err != nil {
+		t.Fatalf("marshal bare: %v", err)
+	}
+	if bytes.Contains(bare, []byte("autofill=")) || bytes.Contains(bare, []byte("first_stamp=")) {
+		t.Errorf("omitempty failed; bare marshal contained new attributes:\n%s", bare)
 	}
 }
 

--- a/fixture.go
+++ b/fixture.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package sic
 
 import "fmt"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/mxschmitt/golang-safe-in-cloud
 
-go 1.23
-
-require golang.org/x/crypto v0.31.0
+go 1.24

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
-golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=

--- a/marshal.go
+++ b/marshal.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package sic
 
 import (

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,15 @@
+# Schema reference
+
+Reference XMLs shipped inside the SafeInCloud macOS client at
+`/Applications/Safe.app/Contents/Resources/`.
+
+| File | Purpose |
+|---|---|
+| `database.xml` | Localized template definition (`@string/...` placeholders, no user data). |
+| `database_demo.xml` | Same templates plus sample card data used by the in-app demo. |
+
+Sourced from Safe.app **v25.3.5** on **2026-05-23**.
+
+These are ground truth for the Go XML structs in `unmarshal.go`. When SafeInCloud
+ships a new format version, refresh these files and reconcile any new attributes
+or elements with the Go structs.

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,14 +1,13 @@
 # Schema reference
 
-Reference XMLs shipped inside the SafeInCloud macOS client at
+**Source:** [SafeInCloud](https://www.safe-in-cloud.com) macOS client, version
+**v25.3.5**, sourced on **2026-05-23** from
 `/Applications/Safe.app/Contents/Resources/`.
 
 | File | Purpose |
 |---|---|
 | `database.xml` | Localized template definition (`@string/...` placeholders, no user data). |
 | `database_demo.xml` | Same templates plus sample card data used by the in-app demo. |
-
-Sourced from Safe.app **v25.3.5** on **2026-05-23**.
 
 These are ground truth for the Go XML structs in `unmarshal.go`. When SafeInCloud
 ships a new format version, refresh these files and reconcile any new attributes

--- a/schema/database.xml
+++ b/schema/database.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database>
+
+    <!-- LABELS -->
+    <label name="@string/busines_label" id="1" />
+    <label name="@string/private_label" id="2" />
+    <label name="@string/web_accounts_label" id="4" type="web_accounts" />
+
+    <!-- TEMPLATES -->
+    <card title="@string/credit_card_template" id="101" symbol="credit_card" color="gray" template="true" autofill="on">
+        <field name="@string/number_field" type="number" autofill="cc-number"/>
+        <field name="@string/owner_field" type="text" autofill="cc-name" />
+        <field name="@string/expires_field" type="expiry" autofill="cc-exp" />
+        <field name="@string/cvv_field" type="pin" autofill="cc-csc" />
+        <field name="@string/pin_field" type="pin" autofill="off" />
+        <field name="@string/blocking_field" type="phone" autofill="off" />
+    </card>
+    <card title="@string/web_account_template" id="102" symbol="web_site" color="gray" template="true" autofill="on">
+        <field name="@string/login_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/url_field" type="website" autofill="url" />
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+    </card>
+    <card title="@string/email_account_template" id="103" symbol="email" color="gray" template="true" autofill="on">
+        <field name="@string/email_field" type="login" autofill="username"  />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/url_field" type="website" autofill="url" />
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+    </card>
+    <card title="@string/login_password_template" id="104" symbol="key" color="gray" template="true" autofill="off">
+        <field name="@string/login_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+    </card>
+    <card title="@string/code_template" id="100" symbol="lock" color="gray" template="true" autofill="off">
+        <field name="@string/code_field" type="password" autofill="current-password" />
+    </card>
+    <card title="@string/id_passport_template" id="105" symbol="id" color="gray" template="true" autofill="off">
+        <field name="@string/number_field" type="number" autofill="off" />
+        <field name="@string/name_field" type="text" autofill="off" />
+        <field name="@string/birthday_field" type="date" autofill="off" />
+        <field name="@string/issued_field" type="date" autofill="off" />
+        <field name="@string/expires_field" type="expiry" autofill="off" />
+    </card>
+    <card title="@string/insurance_template" id="106" symbol="insurance" color="gray" template="true" autofill="off">
+        <field name="@string/number_field" type="number" autofill="off" />
+        <field name="@string/expires_field" type="expiry" autofill="off" />
+        <field name="@string/phone_field" type="phone" autofill="off" />
+    </card>
+    <card title="@string/membership_template" id="107" symbol="membership" color="gray" template="true" autofill="on">
+        <field name="@string/number_field" type="number" autofill="off" />
+        <field name="@string/login_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/url_field" type="website" autofill="url" />
+        <field name="@string/phone_field" type="phone" autofill="off" />
+    </card>
+    <!-- NEW TEMPLATES -->
+    <card title="@string/bank_account_template" id="108" symbol="bank" color="gray" template="true" autofill="on">
+        <field name="@string/bank_field" type="text" autofill="off" />
+        <field name="@string/holder_field" type="text" autofill="off" />
+        <field name="@string/account_field" type="number" autofill="off" />
+        <field name="@string/type_field" type="text" autofill="off" />
+        <field name="@string/swift_field" type="text" autofill="off" />
+        <field name="@string/iban_field" type="text" autofill="off" />
+        <field name="@string/phone_field" type="phone" autofill="off" />
+        <field name="@string/login_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/url_field" type="website" autofill="url" />
+    </card>
+    <card title="@string/driving_license_template" id="109" symbol="id" color="gray" template="true" autofill="off">
+        <field name="@string/number_field" type="text" autofill="off" />
+        <field name="@string/name_field" type="text" autofill="off" />
+        <field name="@string/birthday_field" type="date" autofill="off" />
+        <field name="@string/class_field" type="text" autofill="off" />
+        <field name="@string/expires_field" type="expiry" autofill="off" />
+    </card>
+    <card title="@string/social_security_template" id="110" symbol="social_security" color="gray" template="true" autofill="off">
+        <field name="@string/number_field" type="text" autofill="off" />
+        <field name="@string/name_field" type="text" autofill="off" />
+    </card>
+    <card title="@string/wifi_router_template" id="111" symbol="router" color="gray" template="true" autofill="off">
+        <field name="@string/network_field" type="text" autofill="off" />
+        <field name="@string/ip_address_field" type="number" autofill="off" />
+        <field name="@string/admin_password_field" type="password" autofill="off" />
+        <field name="@string/wifi_password_field" type="password" autofill="current-password" />
+    </card>
+    <card title="@string/internet_provider_template" id="112" symbol="network" color="gray" template="true" autofill="on">
+        <field name="@string/protocol_field" type="text" autofill="off" />
+        <field name="@string/login_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/dns_field" type="number" autofill="off" />
+        <field name="@string/dns_2_field" type="number" autofill="off" />
+        <field name="@string/url_field" type="website" autofill="url" />
+    </card>
+    <card title="@string/software_license_template" id="113" symbol="cd" color="gray" template="true" autofill="on">
+        <field name="@string/email_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/key_field" type="text" autofill="off" />
+        <field name="@string/url_field" type="website" autofill="url" />
+    </card>
+    <card title="@string/totp_template" id="120" symbol="key" color="gray" template="true" autofill="on">
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+        <field name="@string/url_field" type="website" autofill="url" />
+    </card>
+    <card title="@string/custom_template" id="114" color="gray" template="true" autofill="off">
+    </card>
+
+</database>

--- a/schema/database_demo.xml
+++ b/schema/database_demo.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database>
+
+    <!-- LABELS -->
+    <label name="@string/busines_label" id="1" />
+    <label name="@string/private_label" id="2" />
+    <label name="@string/samples_label" id="3" />
+    <label name="@string/web_accounts_label" id="4" type="web_accounts" />
+
+    <!-- TEMPLATES -->
+    <card title="@string/credit_card_template" id="101" symbol="credit_card" color="gray" template="true" autofill="on">
+        <field name="@string/number_field" type="number" autofill="cc-number"/>
+        <field name="@string/owner_field" type="text" autofill="cc-name" />
+        <field name="@string/expires_field" type="expiry" autofill="cc-exp" />
+        <field name="@string/cvv_field" type="pin" autofill="cc-csc" />
+        <field name="@string/pin_field" type="pin" autofill="off" />
+        <field name="@string/blocking_field" type="phone" autofill="off" />
+    </card>
+    <card title="@string/web_account_template" id="102" symbol="web_site" color="gray" template="true" autofill="on">
+        <field name="@string/login_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/url_field" type="website" autofill="url" />
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+    </card>
+    <card title="@string/email_account_template" id="103" symbol="email" color="gray" template="true" autofill="on">
+        <field name="@string/email_field" type="login" autofill="username"  />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/url_field" type="website" autofill="url" />
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+    </card>
+    <card title="@string/login_password_template" id="104" symbol="key" color="gray" template="true" autofill="off">
+        <field name="@string/login_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+    </card>
+    <card title="@string/code_template" id="100" symbol="lock" color="gray" template="true" autofill="off">
+        <field name="@string/code_field" type="password" autofill="current-password" />
+    </card>
+    <card title="@string/id_passport_template" id="105" symbol="id" color="gray" template="true" autofill="off">
+        <field name="@string/number_field" type="text" autofill="off" />
+        <field name="@string/name_field" type="text" autofill="off" />
+        <field name="@string/birthday_field" type="date" autofill="off" />
+        <field name="@string/issued_field" type="date" autofill="off" />
+        <field name="@string/expires_field" type="expiry" autofill="off" />
+    </card>
+    <card title="@string/insurance_template" id="106" symbol="insurance" color="gray" template="true" autofill="off">
+        <field name="@string/number_field" type="number" autofill="off" />
+        <field name="@string/expires_field" type="expiry" autofill="off" />
+        <field name="@string/phone_field" type="phone" autofill="off" />
+    </card>
+    <card title="@string/membership_template" id="107" symbol="membership" color="gray" template="true" autofill="on">
+        <field name="@string/number_field" type="number" autofill="off" />
+        <field name="@string/login_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/url_field" type="website" autofill="url" />
+        <field name="@string/phone_field" type="phone" autofill="off" />
+    </card>
+    <!-- NEW TEMPLATES -->
+    <card title="@string/bank_account_template" id="108" symbol="bank" color="gray" template="true" autofill="on">
+        <field name="@string/bank_field" type="text" autofill="off" />
+        <field name="@string/holder_field" type="text" autofill="off" />
+        <field name="@string/account_field" type="number" autofill="off" />
+        <field name="@string/type_field" type="text" autofill="off" />
+        <field name="@string/swift_field" type="text" autofill="off" />
+        <field name="@string/iban_field" type="text" autofill="off" />
+        <field name="@string/phone_field" type="phone" autofill="off" />
+        <field name="@string/login_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/url_field" type="website" autofill="url" />
+    </card>
+    <card title="@string/driving_license_template" id="109" symbol="id" color="gray" template="true" autofill="off">
+        <field name="@string/number_field" type="text" autofill="off" />
+        <field name="@string/name_field" type="text" autofill="off" />
+        <field name="@string/birthday_field" type="date" autofill="off" />
+        <field name="@string/class_field" type="text" autofill="off" />
+        <field name="@string/expires_field" type="expiry" autofill="off" />
+    </card>
+    <card title="@string/social_security_template" id="110" symbol="social_security" color="gray" template="true" autofill="off">
+        <field name="@string/number_field" type="text" autofill="off" />
+        <field name="@string/name_field" type="text" autofill="off" />
+    </card>
+    <card title="@string/wifi_router_template" id="111" symbol="router" color="gray" template="true" autofill="off">
+        <field name="@string/network_field" type="text" autofill="off" />
+        <field name="@string/ip_address_field" type="number" autofill="off" />
+        <field name="@string/admin_password_field" type="password" autofill="off" />
+        <field name="@string/wifi_password_field" type="password" autofill="current-password" />
+    </card>
+    <card title="@string/internet_provider_template" id="112" symbol="network" color="gray" template="true" autofill="on">
+        <field name="@string/protocol_field" type="text" autofill="off" />
+        <field name="@string/login_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/dns_field" type="number" autofill="off" />
+        <field name="@string/dns_2_field" type="number" autofill="off" />
+        <field name="@string/url_field" type="website" autofill="url" />
+    </card>
+    <card title="@string/software_license_template" id="113" symbol="cd" color="gray" template="true" autofill="on">
+        <field name="@string/email_field" type="login" autofill="username" />
+        <field name="@string/password_field" type="password" autofill="current-password" />
+        <field name="@string/key_field" type="text" autofill="off" />
+        <field name="@string/url_field" type="website" autofill="url" />
+    </card>
+    <card title="@string/totp_template" id="120" symbol="key" color="gray" template="true" autofill="on">
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+        <field name="@string/url_field" type="website" autofill="url" />
+    </card>
+    <card title="@string/custom_template" id="114" color="gray" template="true" autofill="off">
+    </card>
+
+    <!-- SAMPLES -->
+    <card title="Facebook" id="301" symbol="f" color="0xff3f5ca8" autofill="on" star="true">
+        <field name="@string/login_field" type="login" autofill="username">john555@gmail.com</field>
+        <field name="@string/password_field" type="password" autofill="current-password">early91*Fail*301</field>
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code">kqvh wnn7 6zqu 5cua kzcb jlk4 yjww au5b</field>
+        <field name="@string/url_field" type="website" autofill="url">https://facebook.com</field>
+        <label_id>3</label_id>
+    </card>
+    <card title="Airbnb" id="317" symbol="t" color="blue" autofill="on" star="true">
+        <field name="@string/login_field" type="login" autofill="username">john555@gmail.com</field>
+        <field name="@string/password_field" type="password" autofill="current-password">early91*Fail*317</field>
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+        <field name="@string/url_field" type="website" autofill="url">https://airbnb.com</field>
+        <label_id>3</label_id>
+    </card>
+    <card title="Netflix" id="310" symbol="t" color="blue" autofill="on">
+        <field name="@string/login_field" type="login" autofill="username">john555@gmail.com</field>
+        <field name="@string/password_field" type="password" autofill="current-password">early91*Fail*310</field>
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+        <field name="@string/url_field" type="website" autofill="url">https://netflix.com</field>
+        <label_id>3</label_id>
+    </card>
+    <card title="Amazon" id="311" symbol="t" color="blue" autofill="on">
+        <field name="@string/login_field" type="login" autofill="username">john555@gmail.com</field>
+        <field name="@string/password_field" type="password" autofill="current-password">early91*Fail*311</field>
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+        <field name="@string/url_field" type="website" autofill="url">https://amazon.com</field>
+        <label_id>3</label_id>
+    </card>
+    <card title="LinkedIn" id="312" symbol="t" color="blue" autofill="on">
+        <field name="@string/login_field" type="login" autofill="username">john555@gmail.com</field>
+        <field name="@string/password_field" type="password" autofill="current-password">early91*Fail*312</field>
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+        <field name="@string/url_field" type="website" autofill="url">https://linkedin.com</field>
+        <label_id>3</label_id>
+    </card>
+    <card title="Instagram" id="313" symbol="t" color="blue" autofill="on">
+        <field name="@string/login_field" type="login" autofill="username">john555@gmail.com</field>
+        <field name="@string/password_field" type="password" autofill="current-password">early91*Fail*313</field>
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+        <field name="@string/url_field" type="website" autofill="url">https://instagram.com</field>
+        <label_id>3</label_id>
+    </card>
+    <card title="Mastercard" id="315" symbol="visa" color="0xff3f5ca8" autofill="on">
+        <field name="@string/number_field" type="number" autofill="cc-number">5555123456789000</field>
+        <field name="@string/owner_field" type="text" autofill="cc-name">John Smith</field>
+        <field name="@string/expires_field" type="expiry" autofill="cc-exp">01/23</field>
+        <field name="@string/cvv_field" type="pin" autofill="cc-csc">555</field>
+        <field name="@string/pin_field" type="pin" autofill="off">1111</field>
+        <field name="@string/blocking_field" type="phone" autofill="off" />
+        <field name="@string/url_field" type="website" autofill="url">https://mastercard.com</field>
+        <label_id>3</label_id>
+    </card>
+    <card title="PayPal" id="316" symbol="t" color="blue" autofill="on">
+        <field name="@string/login_field" type="login" autofill="username">john555@gmail.com</field>
+        <field name="@string/password_field" type="password" autofill="current-password">early91*Fail*316</field>
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+        <field name="@string/url_field" type="website" autofill="url">https://paypal.com</field>
+        <label_id>3</label_id>
+    </card>
+    <card title="X" id="318" symbol="t" color="blue" autofill="on">
+        <field name="@string/login_field" type="login" autofill="username">john555@gmail.com</field>
+        <field name="@string/password_field" type="password" autofill="current-password">early91*Fail*316</field>
+        <field name="@string/one_time_password_field" type="one_time_password" autofill="one-time-code" />
+        <field name="@string/url_field" type="website" autofill="url">https://twitter.com</field>
+        <label_id>3</label_id>
+    </card>
+
+</database>

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package sic
 
 import (
@@ -5,6 +7,8 @@ import (
 	"fmt"
 )
 
+// Database is the root SafeInCloud database, holding labels, templates, cards,
+// notes, attachments, and tombstones for deleted entries.
 type Database struct {
 	XMLName xml.Name `xml:"database"`
 	Notes   []string `xml:"notes"`
@@ -15,11 +19,14 @@ type Database struct {
 	Card    []Card   `xml:"card"`
 }
 
+// Ghost is a tombstone for a deleted card, retained so sync can propagate the
+// deletion to other clients.
 type Ghost struct {
 	ID        string `xml:"id,attr"`
 	TimeStamp string `xml:"time_stamp,attr"`
 }
 
+// Label is a user- or schema-defined tag that can be attached to cards.
 type Label struct {
 	Type      string `xml:"type,attr"`
 	TimeStamp string `xml:"time_stamp,attr"`
@@ -27,6 +34,8 @@ type Label struct {
 	Name      string `xml:"name,attr"`
 }
 
+// Card is a single SafeInCloud entry such as a login, credit card, or note.
+// Cards with template="true" define the schema for entries created from them.
 type Card struct {
 	ID          string  `xml:"id,attr"`
 	Symbol      string  `xml:"symbol,attr"`
@@ -34,22 +43,28 @@ type Card struct {
 	Type        string  `xml:"type,attr"`
 	WebsiteIcon string  `xml:"website_icon,attr"`
 	TimeStamp   string  `xml:"time_stamp,attr"`
+	FirstStamp  string  `xml:"first_stamp,attr,omitempty"`
 	Deleted     string  `xml:"deleted,attr"`
 	Title       string  `xml:"title,attr"`
 	Color       string  `xml:"color,attr"`
 	Star        string  `xml:"star,attr"`
+	Autofill    string  `xml:"autofill,attr,omitempty"`
 	Field       []Field `xml:"field"`
 }
 
+// Field is a single labelled value within a Card (e.g. a username, password,
+// or PIN).
 type Field struct {
-	Hash    string `xml:"hash,attr"`
-	History string `xml:"history,attr"`
-	Name    string `xml:"name,attr"`
-	Type    string `xml:"type,attr"`
-	Text    string `xml:",chardata"`
-	Score   string `xml:"score,attr"`
+	Hash     string `xml:"hash,attr"`
+	History  string `xml:"history,attr"`
+	Name     string `xml:"name,attr"`
+	Type     string `xml:"type,attr"`
+	Text     string `xml:",chardata"`
+	Score    string `xml:"score,attr"`
+	Autofill string `xml:"autofill,attr,omitempty"`
 }
 
+// File is a binary attachment encoded inline within a Card.
 type File struct {
 	Name string `xml:"name,attr"`
 	Text string `xml:",chardata"`


### PR DESCRIPTION
## Summary
- **CI was silently broken.** Workflow triggered on `master`; default branch was renamed to `main`. Fixed + added a Go matrix (1.24, stable), `go vet`, and a `go mod tidy` verification step.
- **Zero external dependencies.** Migrated `golang.org/x/crypto/pbkdf2` → stdlib `crypto/pbkdf2` (Go 1.24+). Key derivation is bit-identical (verified against `decrypt_test.db`).
- **Schema completeness.** Added `Card.Autofill`, `Card.FirstStamp`, `Field.Autofill` (`omitempty`) — matches real Safe.app v25.3.5 output.
- **Docs.** Package doc, per-type doc comments, SPDX headers, README rewrite (Encrypt example, [safe-in-cloud.com](https://www.safe-in-cloud.com) link, pkg.go.dev badge, format-crypto note).
- **Schema reference.** `schema/database.xml` + `schema/database_demo.xml` copied from Safe.app v25.3.5 as ground truth.
- **Tests.** `TestWriteByteArrayTooLarge`, `TestDecryptCorruptedZlib`, `TestMarshalRoundTripWithNewAttributes` (the omitempty canary). Renamed `TestDecrytionSuccess` typo.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` — all 8 tests pass, including `TestDecryptionSuccess` against the legacy `decrypt_test.db` fixture (proves stdlib pbkdf2 is bit-equivalent) and `TestEncryptDecryptRoundTrip` (proves `omitempty` keeps fixture round-trip stable)
- [x] Real-world decrypt of `~/Library/Containers/.../SafeInCloud.db` (Safe.app v25.3.5) still works
- [ ] CI runs (it will, since trigger is now `main`) and both matrix legs go green